### PR TITLE
feat: Add Gemini 3 Flash Preview model

### DIFF
--- a/structs/models.v
+++ b/structs/models.v
@@ -7,6 +7,7 @@ pub enum Models {
 	gemini_2_0_flash_lite
 	gemini_2_0_flash_thinking_exp_01_21
 	gemini_2_5_flash
+	gemini_3_0_flash_preview
 }
 
 pub fn (m Models) str() string {
@@ -28,6 +29,9 @@ pub fn (m Models) str() string {
 		}
 		.gemini_2_5_flash {
 			'gemini-2.5-flash'
+		}
+		.gemini_3_0_flash_preview {
+			'gemini-3-flash-preview'
 		}
 	}
 }


### PR DESCRIPTION
This expands on the existing `Model` enum in the `struct` module to accommodate the _Gemini 3 Flash Preview_ model. 

Tested the code example in the README.md succesfully. However I saw on other occasions that Gemini 3 seems to use an additional field `thoughtSignature`.