### PR TITLE
Add API key helper and SDK constructor.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,14 @@ v install https://github.com/Ddiidev/sdk_gemini
 import sdk_gemini
 import sdk_gemini.structs
 
-// Initialize the SDK with your API key
-mut sdk := sdk_gemini.GeminiSDK{
-    api_key: $env('GEMINI_API_KEY')
+// Read API key from environment
+api_key := sdk_gemini.get_api_key('GEMINI_API_KEY') or {
+    log.error(err.msg())
+    return
 }
+
+// Initialize the SDK with your API key
+mut sdk := sdk_gemini.new(api_key)
 
 // Send a simple prompt
 response := sdk.send_prompt(

--- a/gemini_api.v
+++ b/gemini_api.v
@@ -1,5 +1,6 @@
 module sdk_gemini
 
+import os
 import json
 import structs
 import net.http
@@ -10,6 +11,25 @@ pub:
 }
 
 const base_url = 'https://generativelanguage.googleapis.com/v1beta/models'
+
+// get_api_key Reads an Gemini API key from an environment variable.
+pub fn get_api_key(key_var string) !string {
+	api_key := os.getenv(key_var)
+	if api_key == '' {
+		return structs.KeyEmptyError{}
+	}
+	if !api_key.starts_with('AIza') {
+		return structs.KeySequenceError{}
+	}
+	return api_key
+}
+
+// new Returns a GeminiSDK.
+pub fn new(api_key string) GeminiSDK {
+	return GeminiSDK{
+		api_key: api_key
+	}
+}
 
 // completation Sends a request to the Gemini API and returns the response.
 pub fn (mut sdk GeminiSDK) completation(model structs.Models, req_payload structs.GeminiRequest) !structs.GeminiResponse {

--- a/structs/errors.v
+++ b/structs/errors.v
@@ -1,0 +1,17 @@
+module structs
+
+pub struct KeyEmptyError {
+	Error
+}
+
+pub struct KeySequenceError {
+	Error
+}
+
+fn (err KeyEmptyError) msg() string {
+	return 'Invalid Key is empty string'
+}
+
+fn (err KeySequenceError) msg() string {
+	return 'Invalid Key starts with invalid sequence'
+}

--- a/tests/gemini_api_test.v
+++ b/tests/gemini_api_test.v
@@ -1,0 +1,42 @@
+module tests
+
+import sdk_gemini
+import structs
+import os
+
+fn test_get_api_key_not_exist() ! {
+	got := sdk_gemini.get_api_key('NOT_EXIST') or {
+		if err is structs.KeyEmptyError {
+			return
+		} else {
+			return err
+		}
+	}
+}
+
+fn test_get_api_key_invalid() ! {
+	key := 'abcd0123456789'
+	os.setenv('MOCK_API_KEY', key, true)
+	got := sdk_gemini.get_api_key('MOCK_API_KEY') or {
+		if err is structs.KeySequenceError {
+			return
+		} else {
+			return err
+		}
+	}
+}
+
+fn test_get_api_key_valid() ! {
+	key := 'AIza0123456789'
+	os.setenv('MOCK_API_KEY', key, true)
+	got := sdk_gemini.get_api_key('MOCK_API_KEY') or { return err }
+	assert got == key
+}
+
+fn test_new() ! {
+	key := 'AIza0123456789'
+	got := sdk_gemini.new(key)
+	assert got == sdk_gemini.GeminiSDK{
+		api_key: key
+	}
+}


### PR DESCRIPTION
- `new` function to create a GeminiSDK struct in an idiomatic way.
- `get_api_key` function to read an API key from an environment variable and performing basic sanity checks on the result, encouraging the best practice to keep API keys out of the code base.
- `KeyEmptyError`, `KeySequenceError` as custom errors.

Finally `README.md` is updated accordingly to the changes above.

***Note***: I had some trouble running the new tests querying the various models (see below) and did not add a test for `get_api_key` and did not change the tests to use it. 
```
"error": {
    "code": 503,
    "message": "The model is overloaded. Please try again later.",
    "status": "UNAVAILABLE"
  }
}
```