### PR TITLE
Update error handling in API and README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ response := sdk.send_prompt(
     'Tell me about João Pessoa, Paraíba',
     'You are a tour guide from Brazil, specifically from the Northeast region, João Pessoa and Paraíba state'
 ) or {
-    panic('Failed to get response: ${err}')
+		log.error(err.code().str() + ': ' + err.msg())
+		return
 }
 
 // Access the response

--- a/gemini_api.v
+++ b/gemini_api.v
@@ -47,8 +47,18 @@ pub fn (mut sdk GeminiSDK) completation(model structs.Models, req_payload struct
 
 	resp := req.do()!
 
-	if resp.status_code != 200 {
-		return error_with_code(resp.body, resp.status_code)
+	match resp.status_code {
+		429 {
+			return error_with_code('exceeded current quota', resp.status_code)
+		}
+		503 {
+			return error_with_code('model is overloaded', resp.status_code)
+		}
+		else {
+			if resp.status_code != 200 {
+				return error_with_code(resp.body, resp.status_code)
+			}
+		}
 	}
 
 	decoded := json.decode(structs.GeminiResponse, resp.body)!


### PR DESCRIPTION
Turns a model's long text based _non-200_ status responses in short errors that can be logged preserving the original error code and demonstrating this in `README.md` code example.

In `fn completation` / `resp.status_codes` :
- 200 -> OK
- 420 -> returns error _exceeded current quota_ and code _420_
- 503 -> returns error _model is overloaded_ and code _503_

***Note:*** This is a proposal, possibly there are better ways to handle this. However, this seems for now the simplest way and it can be easily extended as new error codes are encountered.