### PR TITLE
Handle 400 Bad Request for invalid JSON payload.

### DIFF
--- a/gemini_api.v
+++ b/gemini_api.v
@@ -48,6 +48,9 @@ pub fn (mut sdk GeminiSDK) completation(model structs.Models, req_payload struct
 	resp := req.do()!
 
 	match resp.status_code {
+		400 {
+			return error_with_code('invalid JSON payload', resp.status_code)
+		}
 		429 {
 			return error_with_code('exceeded current quota', resp.status_code)
 		}


### PR DESCRIPTION
Another short-hand error handle for a common error. The full length response here was:

```json
2026-01-26T20:14:48.656950Z [ERROR] 400: {
  "error": {
    "code": 400,
    "message": "Invalid JSON payload received. Unknown name \"parts_idx\" at 'contents[0]': Cannot find field.",
    "status": "INVALID_ARGUMENT",
    "details": [
      {
        "@type": "type.googleapis.com/google.rpc.BadRequest",
        "fieldViolations": [
          {
            "field": "contents[0]",
            "description": "Invalid JSON payload received. Unknown name \"parts_idx\" at 'contents[0]': Cannot find field."
          }
        ]
      }
    ]
  }
}
```