### PR TITLE
feat: Improve error handling with specific types and debug logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ v install https://github.com/Ddiidev/sdk_gemini
 import sdk_gemini
 import sdk_gemini.structs
 
+//log level 'debug' provides full model response when errors occur
+log.set_level(.debug)
+
 // Read API key from environment
 api_key := sdk_gemini.get_api_key('GEMINI_API_KEY') or {
     log.error(err.msg())
@@ -47,7 +50,7 @@ response := sdk.send_prompt(
     'Tell me about João Pessoa, Paraíba',
     'You are a tour guide from Brazil, specifically from the Northeast region, João Pessoa and Paraíba state'
 ) or {
-		log.error(err.code().str() + ': ' + err.msg())
+		log.error(err.msg())
 		return
 }
 

--- a/gemini_api.v
+++ b/gemini_api.v
@@ -48,6 +48,9 @@ pub fn (mut sdk GeminiSDK) completation(model structs.Models, req_payload struct
 	resp := req.do()!
 
 	match resp.status_code {
+		400 {
+			return error_with_code('invalid JSON payload', resp.status_code)
+		}
 		429 {
 			return error_with_code('exceeded current quota', resp.status_code)
 		}

--- a/structs/errors.v
+++ b/structs/errors.v
@@ -8,10 +8,42 @@ pub struct KeySequenceError {
 	Error
 }
 
+pub struct InvalidPayloadError {
+	Error
+}
+
+pub struct ExceededQuotaError {
+	Error
+}
+
+pub struct ModelOverloadedError {
+	Error
+}
+
+pub struct UnknownResponseError {
+	Error
+}
+
 fn (err KeyEmptyError) msg() string {
 	return 'Invalid Key is empty string'
 }
 
 fn (err KeySequenceError) msg() string {
 	return 'Invalid Key starts with invalid sequence'
+}
+
+fn (err InvalidPayloadError) msg() string {
+	return 'Model received invalid JSON payload (code 400)'
+}
+
+fn (err ExceededQuotaError) msg() string {
+	return 'Exceeded current quota for model (code 429)'
+}
+
+fn (err ModelOverloadedError) msg() string {
+	return 'Model is overloaded (code 503)'
+}
+
+fn (err UnknownResponseError) msg() string {
+	return 'Unknown model response error (code != 200)'
 }


### PR DESCRIPTION
This builds on PR #9 and improves the error handling in `fn completation` further with specific types and debug logging and shows a usage example in `README.md`. Errors are consolidated in `structs/errors.v`, where the error code is now available by calling the error method via `.msg()`. If the log level is set to _debug_ the full model response is logged before the error is returned.