### PR TITLE
feat for example chatbot: dependency-free spinner added

### DIFF
--- a/example/sdk_gemini_chat.v
+++ b/example/sdk_gemini_chat.v
@@ -2,6 +2,7 @@ module main
 
 import sdk_gemini
 import sdk_gemini.structs
+import time
 import log
 import os
 
@@ -20,7 +21,16 @@ mut:
 	response_buffer    string
 }
 
+pub struct Spinner {
+	set  []string
+	done chan bool
+mut:
+	run bool
+}
+
 fn main() {
+	log.set_level(.error)
+
 	help_string := ':q to exit | :w write to file'
 
 	conf := ReplConfig{
@@ -30,9 +40,11 @@ fn main() {
 		file_out: 'gemini_response.md'
 	}
 
-	mut repl := ReplState{}
+	shared spin := Spinner{
+		set: ['.', '..', '...', ' ']
+	}
 
-	log.set_level(.debug)
+	mut repl := ReplState{}
 
 	api_key := sdk_gemini.get_api_key('GEMINI_API_KEY') or {
 		log.error(err.msg())
@@ -71,10 +83,13 @@ fn main() {
 				continue
 			}
 			else {
+				spin.start()
 				repl.response_buffer = get_response(mut sdk, conf, mut repl) or {
+					spin.stop()
 					log.error(err.msg())
-					continue
+					exit(1)
 				}
+				spin.stop()
 				print_response(conf, repl.response_buffer)
 			}
 		}
@@ -98,4 +113,46 @@ fn print_response(conf ReplConfig, msg string) {
 
 fn write_response_buffer(conf ReplConfig, repl ReplState) ! {
 	os.write_file(conf.file_out, repl.response_buffer) or { return err }
+}
+
+pub fn (shared s Spinner) start() {
+	lock s {
+		s.run = true
+	}
+	// hides cursor
+	print('\033[?25l')
+	flush_stdout()
+	go fn [shared s] () {
+		for {
+			if s.run {
+				for v in s.set {
+					print(v)
+					flush_stdout()
+					time.sleep(200 * time.millisecond)
+					// erase current line  and reset cursor to start of current line
+					print('\033[K\r')
+					flush_stdout()
+				}
+			} else {
+				print('\033[K\r')
+				flush_stdout()
+				// makecursor visible
+				print('\033[?25h')
+				flush_stdout()
+				s.done <- true
+				return
+			}
+		}
+	}()
+}
+
+pub fn (shared s Spinner) stop() {
+	lock s {
+		s.run = false
+	}
+	select {
+		_ := <-s.done {
+			return
+		}
+	}
 }


### PR DESCRIPTION
I added a spinner to the chatbot example that has no external dependencies. It's maybe a bit over the top but it adds a nice visual touch and also demonstrates several typical concurrency patterns in `V` on which users could build. 

If you feel this needlessly complicates the example, please feel free to reject this PR. 